### PR TITLE
to make work with python3

### DIFF
--- a/src/python/chadwick/__init__.py
+++ b/src/python/chadwick/__init__.py
@@ -21,12 +21,12 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 
-from libchadwick import create_game
-from libchadwick import read_game
+from chadwick.libchadwick import create_game
+from chadwick.libchadwick import read_game
 
-from libchadwick import create_scorebook
-from libchadwick import read_scorebook
+from chadwick.libchadwick import create_scorebook
+from chadwick.libchadwick import read_scorebook
 
-from libchadwick import create_league
-from libchadwick import read_league
+from chadwick.libchadwick import create_league
+from chadwick.libchadwick import read_league
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -30,8 +30,8 @@ setup(name="chadwick",
       author_email="ted.turocy@gmail.com",
       url="http://chadwick.sourceforge.net",
       packages=['chadwick'],
-      ext_modules=[Extension('chadwick._libchadwick',
-                             ['chadwick/libchadwick.i',
+      ext_modules=[Extension('_libchadwick',
+                             sources=['chadwick/libchadwick.i',
                               '../cwlib/book.c',
                               '../cwlib/box.c',
                               '../cwlib/file.c',
@@ -42,6 +42,6 @@ setup(name="chadwick",
                               '../cwlib/parse.c',
                               '../cwlib/roster.c'],
                              include_dirs=['../cwlib'],
-                             swig_opts=['-I../cwlib'] )]
+                             swig_opts=['-I../cwlib', '-py3'] )]
       )
 


### PR DESCRIPTION
This works.
The naming parts in setup.py and **init**.py are fine. but the -py3 option in setup.py is obviously a problem.
I am guessing there would need to be 2 setup.py files to support both.
