### PR TITLE
added AM_INIT_AUTOMAKE([foreign]) to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@
 AC_INIT([chadwick], [0.8.1])
 AC_CONFIG_SRCDIR([src/cwlib/chadwick.h])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 dnl Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Fix for #31 