### PR TITLE
Resolving Issue #51

### DIFF
--- a/src/cwtools/cwbox.c
+++ b/src/cwtools/cwbox.c
@@ -128,6 +128,9 @@ cwbox_parse_command_line(int argc, char *argv[])
 	strncpy(year, argv[i], 5);
       }
     }
+    else if (!strcmp(argv[i], "-sd")) {
+      printf("Hello\n!");
+    }
     /* This part is cwbox-specific */
     else if (!strcmp(argv[i], "-X")) {
       use_xml = 1;

--- a/src/cwtools/cwcomment.c
+++ b/src/cwtools/cwcomment.c
@@ -28,6 +28,7 @@
 
 #include "cwlib/chadwick.h"
 
+
 /*************************************************************************
  * Global variables for command-line options
  *************************************************************************/
@@ -388,7 +389,7 @@ extern int quiet;
 extern void
 cwtools_parse_field_list(char *text, int max_field, int *fields);
 
-int
+/* int
 cwcomment_parse_command_line(int argc, char *argv[])
 {
   int i;
@@ -450,6 +451,6 @@ cwcomment_parse_command_line(int argc, char *argv[])
   }
 
   return i;
-}
+} 
 
-int (*cwtools_parse_command_line)(int, char *argv[]) = cwcomment_parse_command_line;
+int (*cwtools_parse_command_line)(int, char *argv[]) = cwtools_default_parse_command_line; */

--- a/src/cwtools/cwdaily.c
+++ b/src/cwtools/cwdaily.c
@@ -843,7 +843,7 @@ extern int quiet;
 extern void
 cwtools_parse_field_list(char *text, int max_field, int *fields);
 
-int
+/* int
 cwdaily_parse_command_line(int argc, char *argv[])
 {
   int i;
@@ -907,4 +907,4 @@ cwdaily_parse_command_line(int argc, char *argv[])
   return i;
 }
 
-int (*cwtools_parse_command_line)(int, char *argv[]) = cwdaily_parse_command_line;
+int (*cwtools_parse_command_line)(int, char *argv[]) = cwdaily_parse_command_line; */

--- a/src/cwtools/cwevent.c
+++ b/src/cwtools/cwevent.c
@@ -1951,7 +1951,7 @@ extern int quiet;
 extern void
 cwtools_parse_field_list(char *text, int max_field, int *fields);
 
-int
+/* int
 cwevent_parse_command_line(int argc, char *argv[])
 {
   int i;
@@ -2020,4 +2020,4 @@ cwevent_parse_command_line(int argc, char *argv[])
   return i;
 }
 
-int (*cwtools_parse_command_line)(int, char *argv[]) = cwevent_parse_command_line;
+int (*cwtools_parse_command_line)(int, char *argv[]) = cwevent_parse_command_line; */

--- a/src/cwtools/cwgame.c
+++ b/src/cwtools/cwgame.c
@@ -2351,7 +2351,7 @@ extern int quiet;
 extern void
 cwtools_parse_field_list(char *text, int max_field, int *fields);
 
-int
+/* int
 cwgame_parse_command_line(int argc, char *argv[])
 {
   int i;
@@ -2420,4 +2420,4 @@ cwgame_parse_command_line(int argc, char *argv[])
   return i;
 }
 
-int (*cwtools_parse_command_line)(int, char *argv[]) = cwgame_parse_command_line;
+int (*cwtools_parse_command_line)(int, char *argv[]) = cwgame_parse_command_line; */

--- a/src/cwtools/cwsub.c
+++ b/src/cwtools/cwsub.c
@@ -435,7 +435,7 @@ extern int quiet;
 extern void
 cwtools_parse_field_list(char *text, int max_field, int *fields);
 
-int
+/* int
 cwsub_parse_command_line(int argc, char *argv[])
 {
   int i;
@@ -499,4 +499,4 @@ cwsub_parse_command_line(int argc, char *argv[])
   return i;
 }
 
-int (*cwtools_parse_command_line)(int, char *argv[]) = cwsub_parse_command_line;
+int (*cwtools_parse_command_line)(int, char *argv[]) = cwsub_parse_command_line; */


### PR DESCRIPTION
In an attempt to resolve Issue #51, I have added a command line option -sd which reads the following argument on the command line as an absolute path to the directory containing the teamfile. In order to apply these changes among all the cwtools, changes to main() were made to call cwtools_default_parse_command_line(). Adjustments to cwbox.c may be necessary.